### PR TITLE
make functions static and report panel orientation

### DIFF
--- a/arch/arm64/boot/dts/apple/t8103-j293.dts
+++ b/arch/arm64/boot/dts/apple/t8103-j293.dts
@@ -144,6 +144,7 @@
 	dfr_panel: panel@0 {
 		compatible = "apple,summit";
 		reg = <0>;
+		rotation = <90>;
 	};
 };
 

--- a/arch/arm64/boot/dts/apple/t8112-j493.dts
+++ b/arch/arm64/boot/dts/apple/t8112-j493.dts
@@ -53,6 +53,7 @@
 	dfr_panel: panel@0 {
 		compatible = "apple,summit";
 		reg = <0>;
+		rotation = <90>;
 	};
 };
 

--- a/drivers/gpu/drm/adp/adp_drv.c
+++ b/drivers/gpu/drm/adp/adp_drv.c
@@ -82,7 +82,7 @@
 #define GEN_RD_CMD_BUSY BIT(6)
 #define CMD_PKT_STATUS_TIMEOUT_US 20000
 
-int adp_open(struct inode *inode, struct file *filp)
+static int adp_open(struct inode *inode, struct file *filp)
 {
 	/*
 	 * The modesetting driver does not check the non-desktop connector

--- a/drivers/gpu/drm/adp/adp_drv.c
+++ b/drivers/gpu/drm/adp/adp_drv.c
@@ -513,6 +513,12 @@ static int adp_setup_mode_config(struct adp_drv_private *adp)
 	if (ret)
 		return ret;
 
+	/* This should come from the dts / panel */
+	ret = drm_connector_set_panel_orientation(&adp->connector,
+				DRM_MODE_PANEL_ORIENTATION_RIGHT_UP);
+	if (ret)
+		return ret;
+
 	drm_connector_attach_encoder(&adp->connector, &adp->encoder);
 
 	ret = drm_vblank_init(drm, drm->mode_config.num_crtc);

--- a/drivers/gpu/drm/adp/adp_drv.c
+++ b/drivers/gpu/drm/adp/adp_drv.c
@@ -252,7 +252,8 @@ static const u32 plane_formats[] = {
 
 #define ALL_CRTCS 1
 
-struct adp_plane *adp_plane_new(struct adp_drv_private *adp, u8 id)
+static struct adp_plane *adp_plane_new(struct adp_drv_private *adp,
+				       u8 id)
 {
 	struct drm_device *drm = &adp->drm;
 	struct adp_plane *plane;
@@ -434,7 +435,7 @@ static int adp_get_modes(struct drm_connector *connector)
 	return 1;
 }
 
-int adp_detect_ctx(struct drm_connector *connector,
+static int adp_detect_ctx(struct drm_connector *connector,
 		   struct drm_modeset_acquire_ctx *ctx,
 		   bool force) {
 	connector->display_info.non_desktop = true;


### PR DESCRIPTION
kernel robot complained about missing prototypes for the non-static functions. Panel orientation is an hack for now, should come directly from the dts but that needs an actual drm_panel implementation.